### PR TITLE
Fix 'Can't close an AudioContext twice' for firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-audio-visualize",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-audio-visualize",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-audio-visualize",
   "private": false,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "author": "",
   "repository": {
@@ -21,7 +21,8 @@
     "audio waveform",
     "waveform",
     "audio visualization",
-    "visualization"
+    "visualization",
+    "live visualize"
   ],
   "files": [
     "dist"

--- a/src/LiveAudioVisualizer/LiveAudioVisualizer.tsx
+++ b/src/LiveAudioVisualizer/LiveAudioVisualizer.tsx
@@ -107,7 +107,7 @@ const LiveAudioVisualizer: (props: Props) => ReactElement = ({
   }, [mediaRecorder.stream]);
 
   useEffect(() => {
-    if (analyser ?? mediaRecorder.state === "recording") {
+    if (analyser && mediaRecorder.state === "recording") {
       report();
     }
   }, [analyser, mediaRecorder.state]);
@@ -129,7 +129,7 @@ const LiveAudioVisualizer: (props: Props) => ReactElement = ({
     ) {
       context.close();
     }
-  }, [analyser]);
+  }, [analyser, context.state]);
 
   const processFrequencyData = (data: Uint8Array): void => {
     if (!canvasRef.current) return;


### PR DESCRIPTION
Error:
![image](https://github.com/samhirtarif/react-audio-visualize/assets/89391183/87c5d17b-a366-4f5c-8d4a-961eb48fc16e)

This PR resolves [react-audio-recorder](https://github.com/samhirtarif/react-audio-recorder) [#53](https://github.com/samhirtarif/react-audio-recorder/issues/53)