### PR TITLE
cleanup audio context on unmount

### DIFF
--- a/src/LiveAudioVisualizer/LiveAudioVisualizer.tsx
+++ b/src/LiveAudioVisualizer/LiveAudioVisualizer.tsx
@@ -107,7 +107,9 @@ const LiveAudioVisualizer: (props: Props) => ReactElement = ({
   }, [mediaRecorder.stream]);
 
   useEffect(() => {
+    if (analyser && mediaRecorder.state === "recording") {
       report();
+    }
   }, [analyser, mediaRecorder.state]);
 
   const report = useCallback(() => {
@@ -121,8 +123,13 @@ const LiveAudioVisualizer: (props: Props) => ReactElement = ({
       requestAnimationFrame(report);
     } else if (mediaRecorder.state === "paused") {
       processFrequencyData(data);
+    } else if (
+      mediaRecorder.state === "inactive" &&
+      context.state !== "closed"
+    ) {
+      context.close();
     }
-  }, [analyser]);
+  }, [analyser, context.state]);
 
   useEffect(() => {
     if (context.state !== "closed") {

--- a/src/LiveAudioVisualizer/LiveAudioVisualizer.tsx
+++ b/src/LiveAudioVisualizer/LiveAudioVisualizer.tsx
@@ -132,8 +132,10 @@ const LiveAudioVisualizer: (props: Props) => ReactElement = ({
   }, [analyser, context.state]);
 
   useEffect(() => {
-    if (context.state !== "closed") {
-      context.close();
+    return () => {
+      if (context.state !== "closed") {
+        context.close();
+      }
     }
   }, []);
 

--- a/src/LiveAudioVisualizer/LiveAudioVisualizer.tsx
+++ b/src/LiveAudioVisualizer/LiveAudioVisualizer.tsx
@@ -107,9 +107,7 @@ const LiveAudioVisualizer: (props: Props) => ReactElement = ({
   }, [mediaRecorder.stream]);
 
   useEffect(() => {
-    if (analyser && mediaRecorder.state === "recording") {
       report();
-    }
   }, [analyser, mediaRecorder.state]);
 
   const report = useCallback(() => {
@@ -123,13 +121,14 @@ const LiveAudioVisualizer: (props: Props) => ReactElement = ({
       requestAnimationFrame(report);
     } else if (mediaRecorder.state === "paused") {
       processFrequencyData(data);
-    } else if (
-      mediaRecorder.state === "inactive" &&
-      context.state !== "closed"
-    ) {
+    }
+  }, [analyser]);
+
+  useEffect(() => {
+    if (context.state !== "closed") {
       context.close();
     }
-  }, [analyser, context.state]);
+  }, []);
 
   const processFrequencyData = (data: Uint8Array): void => {
     if (!canvasRef.current) return;


### PR DESCRIPTION
Close audio context on unmount. 

We ran into issues with the library leaving audio contexts open, eventually causing other audio contexts on the page to stop working properly. The current logic around closing the audio context did not kick off for us as we pause, then stop the media recorder.